### PR TITLE
Add support for variable-width typefaces

### DIFF
--- a/src/components/language/BabelDevice.cpp
+++ b/src/components/language/BabelDevice.cpp
@@ -131,7 +131,7 @@ bool BabelDevice::fetch_glyph_data(BABEL_CODEPOINT codepoint, BabelGlyph *glyph)
     
     loc = BABEL_INFO_GET_GLYPH_LOCATION(glyph->info);
 
-    if (BABEL_INFO_GET_GLYPH_WIDTH(glyph->info) == 16) {
+    if (BABEL_INFO_GET_GLYPH_WIDTH(glyph->info) > 8) {
         this->read(loc, &glyph->glyphData, 32);
         return retVal;
     } else {


### PR DESCRIPTION
I'm working on a new version of babel.bin that supports proportional type rendering, which is a lot more readable. This one change should be enough to get it working once I release it.